### PR TITLE
fix: checkbox selection

### DIFF
--- a/Code.ts
+++ b/Code.ts
@@ -30,9 +30,10 @@
 // Triggers whenever ANY cell is modified.
 // We ensure the sheet has [calc] in the name to allow you to store other data in the spreadsheet
 function onEdit(edit: GoogleAppsScript.Events.SheetsOnEdit) {
+  const checkboxCols = [3, 5, 7, 9, 11, 13];
   const sheetName = edit.range.getSheet().getName()
   if (sheetName.includes('[calc]') && edit.range.getRow() > 1 && edit.range.getColumn() > 1 && edit.range.getColumn() < 16) {
-    if (edit.range.getColumn() % 2 === 0) {
+    if (checkboxCols.includes(edit.range.getColumn())) {
       toggleChart(edit.range, edit.value)
     } else {
       updateSheet(edit.range)

--- a/Code.ts
+++ b/Code.ts
@@ -30,7 +30,7 @@
 // Triggers whenever ANY cell is modified.
 // We ensure the sheet has [calc] in the name to allow you to store other data in the spreadsheet
 function onEdit(edit: GoogleAppsScript.Events.SheetsOnEdit) {
-  const checkboxCols = [3, 5, 7, 9, 11, 13];
+  const checkboxCols = [3, 5, 7, 9, 11, 13]; // [D, F, H, J, L, N]
   const sheetName = edit.range.getSheet().getName()
   if (sheetName.includes('[calc]') && edit.range.getRow() > 1 && edit.range.getColumn() > 1 && edit.range.getColumn() < 16) {
     if (checkboxCols.includes(edit.range.getColumn())) {


### PR DESCRIPTION
In the spreadsheet I cloned from the readme, my checkbox columns are at `[D, F, H, J, L, N]`.

![image](https://user-images.githubusercontent.com/3905798/79079973-42980900-7ce0-11ea-8c55-0be5d5b7da36.png)

When I enter data into the first row, it appears to generate predictions into the cells as expected. However, entering data into any other row does nothing. It looks like the logic for choosing whether to `toggleChart` or `updateSheet` is inverted.

This PR changes the logic so that checkbox columns are explicitly detected. (The above screenshot was taken with this fix applied.)
