### PR TITLE
fix: checkbox selection (v2)

### DIFF
--- a/Code.ts
+++ b/Code.ts
@@ -32,7 +32,8 @@
 function onEdit(edit: GoogleAppsScript.Events.SheetsOnEdit) {
   const sheetName = edit.range.getSheet().getName()
   if (sheetName.includes('[calc]') && edit.range.getRow() > 1 && edit.range.getColumn() > 1 && edit.range.getColumn() < 16) {
-    if (edit.range.getColumn() % 2 === 0) {
+    const col = edit.range.getColumn()
+    if (col >= 4 && col <= 14 && col % 2 === 0) {
       toggleChart(edit.range, edit.value)
     } else {
       updateSheet(edit.range)


### PR DESCRIPTION
This PR restricts the range of checkbox detection to `[D, F, H, J, L, N]`.

As discussed in #3, the current "is this a checkbox" decision unintentionally catches the "Sunday Offer" column, calling `toggleChart` by mistake.

With this change, modifying a cell in the "Sunday Offer" column will trigger an `updateSheet` instead (I believe this is the intended behavior).